### PR TITLE
#167289068 Users should be able to view all property adverts

### DIFF
--- a/controllers/adverts.js
+++ b/controllers/adverts.js
@@ -51,3 +51,30 @@ exports.createAdvert = async (req, res) => {
     },
   });
 };
+
+exports.allAdverts = async (req, res) => {
+  const query = 'SELECT * FROM property';
+  const { rows } = await db.query(query);
+  const advertList = [];
+  rows.forEach((row) => {
+    const data = {
+      id: row.id,
+      Status: row.status,
+      Description: row.description,
+      Type: row.type,
+      State: row.state,
+      City: row.city,
+      Address: row.address,
+      Price: row.price,
+      Image: row.imageUrl,
+      created_on: row.createdon,
+      created_by_staffId: row.owner,
+    };
+    advertList.push(data);
+  });
+  return res.status(200).json({
+    status: 200,
+    message: 'Adverts Successfully Retrieved!',
+    data: advertList,
+  });
+};

--- a/routes/ads.js
+++ b/routes/ads.js
@@ -11,5 +11,6 @@ adRouter
   .post(middleware.verifyToken, validateEmptyFields,
     validatePrice, advertController.createAdvert);
 adRouter.route('/property/type/:type').get(searchController.searchAdvert);
+adRouter.route('/property').get(advertController.allAdverts);
 
 module.exports = adRouter;

--- a/test/adverts.js
+++ b/test/adverts.js
@@ -72,4 +72,15 @@ describe('CREATE AN ADVERT ', () => {
           });
       });
   });
+  it('should return 200 on successful retrieval', (done) => {
+    chai.request(app)
+      .get('/api/v1/property')
+      .end((error, resp) => {
+        if (error) done();
+        resp.should.have.status(200);
+        resp.body.should.be.a('object');
+        resp.body.should.have.property('data');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
- Users should be able to view all property adverts
#### Description of Task to be completed?
- create an endpoint that returns all property adverts
#### How should this be manually tested?
- `git checkout ft-all-adverts-167289068` 
- hit this endpoint `http://localhost:5000/api/v1/property`
#### What are the relevant pivotal tracker stories?
- [#167289068](https://www.pivotaltracker.com/story/show/167289068)
#### Screenshots (if appropriate)
![Screenshot (37)](https://user-images.githubusercontent.com/39625835/60431303-22430600-9c08-11e9-9c81-29987cf9c288.png)
