### PR TITLE
#167289255 Users should be able to view properties of the same type

### DIFF
--- a/controllers/searchAdverts.js
+++ b/controllers/searchAdverts.js
@@ -1,0 +1,22 @@
+import db from '../db';
+
+exports.searchAdvert = async (req, res) => {
+  const { params: { type } } = req;
+
+  const query = 'SELECT * FROM property WHERE type = $1';
+  const propertyAd = await db.query(query, [type]);
+  if (propertyAd.rows.length === 0) {
+    return res.status(400).json({
+      status: 400,
+      message: 'Adverts Not Found !',
+      error: `There are no properties of type: ${type}`,
+
+    });
+  }
+
+  return res.status(200).json({
+    status: 200,
+    message: 'Adverts Found !',
+    data: propertyAd.rows,
+  });
+};

--- a/routes/ads.js
+++ b/routes/ads.js
@@ -1,6 +1,6 @@
 import Router from 'express';
-
 import advertController from '../controllers/adverts';
+import searchController from '../controllers/searchAdverts';
 import middleware from '../middleware';
 import { validateEmptyFields, validatePrice } from '../middleware/property';
 
@@ -8,6 +8,8 @@ const adRouter = Router();
 
 adRouter
   .route('/property')
-  .post(middleware.verifyToken, validateEmptyFields, validatePrice, advertController.createAdvert);
+  .post(middleware.verifyToken, validateEmptyFields,
+    validatePrice, advertController.createAdvert);
+adRouter.route('/property/type/:type').get(searchController.searchAdvert);
 
 module.exports = adRouter;

--- a/test/base.js
+++ b/test/base.js
@@ -83,6 +83,16 @@ exports.signup_user_8 = {
   isAdmin: true,
 };
 
+exports.signup_user_9 = {
+  email: 'danny@gmail.com',
+  password: 'somestring1',
+  lastName: 'nuwa',
+  firstName: 'daniel',
+  phoneNumber: '+256701354725',
+  address: 'plot 12 bukoto street',
+  isAdmin: true,
+};
+
 exports.login_user_8 = {
   email: 'nuwagaba@gmail.com',
   password: 'somestring1',
@@ -107,5 +117,16 @@ exports.advert_2 = {
   city: 'kampala',
   address: 'bukoto street',
   price: '!@$123',
+  imageUrl: 'https://cdn-images-1.medium.com/max/1200/1*RKZ5NBNqwlLXA6vewu7xmw.jpeg',
+};
+
+exports.advert_3 = {
+  status: 'available',
+  description: 'houses in kigali city center',
+  type: 'residential',
+  state: 'available',
+  city: 'kampala',
+  address: 'bukoto street',
+  price: '10000',
   imageUrl: 'https://cdn-images-1.medium.com/max/1200/1*RKZ5NBNqwlLXA6vewu7xmw.jpeg',
 };

--- a/test/searchAdverts.js
+++ b/test/searchAdverts.js
@@ -1,0 +1,50 @@
+/* eslint-disable no-undef */
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index';
+import base from './base';
+
+const LOGIN_URL = '/api/v1/auth/signin';
+const SIGNUP_URL = '/api/v1/auth/signup';
+
+// Configure chai
+chai.use(chaiHttp);
+chai.should();
+
+describe('GET SAME TYPE ADVERTS ', () => {
+  it('should return 201 on success', (done) => {
+    chai.request(app)
+      .post(SIGNUP_URL)
+      .send(base.signup_user_9)
+      .end((err, res) => {
+        if (err) done();
+        chai.request(app)
+          .post('/api/v1/property')
+          .set('x-access-token', res.body.data.token)
+          .send(base.advert_3)
+          .end((error, resp) => {
+            if (error) done();
+            chai.request(app)
+              .get('/api/v1/property/type/residential')
+              .end((er, response) => {
+                if (er) done();
+                response.should.have.status(200);
+                response.body.should.be.a('object');
+                response.body.should.have.property('data');
+                done();
+              });
+          });
+      });
+  });
+  it('should return 400 if no advert found', (done) => {
+    chai.request(app)
+      .get('/api/v1/property/type/bombadia')
+      .end((error, resp) => {
+        if (error) done();
+        resp.should.have.status(400);
+        resp.body.should.be.a('object');
+        resp.body.should.have.property('error');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
- Users should be able to view all property advertisement offering a specific type of property
#### Description of Task to be completed?
- add search endpoint 
#### How should this be manually tested?
- `git checkout ft-sametype-properties-167289255`
- `npm run dev`
- create several property adverts
-  use the endpoint to search through `http://localhost:5000/api/v1/property/type/propertyType`
#### What are the relevant pivotal tracker stories?
- [#167289255](https://www.pivotaltracker.com/story/show/167289255)
#### Screenshots (if appropriate)
![Screenshot (40)](https://user-images.githubusercontent.com/39625835/60542419-9242b080-9d1c-11e9-9348-f9df7575146e.png)